### PR TITLE
change unicode escaping characters to lower case

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # bdc 1.1.1
 
 - `bdc_country_from_coordinates` now filter out countries with no data (`NA`).
+- fix a minor issue of `bdc_clean_names` character encoding on debian-clang CRAN server.
 
 # bdc 1.1.0
 

--- a/R/bdc_clean_names.R
+++ b/R/bdc_clean_names.R
@@ -928,10 +928,10 @@ bdc_gnparser <- function(data, sci_names) {
     stringi::stri_trans_general(str = data_temp$temp, id = "Latin-ASCII") %>%
     stringr::str_squish()
 
-  data_temp$temp <- gsub("\u00B2?", "", data_temp$temp) # get ²?
-  data_temp$temp <- gsub("\u00B2", "", data_temp$temp) # get ²
+  data_temp$temp <- gsub("\u00b2?", "", data_temp$temp) # get ²?
+  data_temp$temp <- gsub("\u00b2", "", data_temp$temp) # get ²
   data_temp$temp <- gsub("?", "", data_temp$temp)
-  data_temp$temp <- gsub("\u00B4", " ", data_temp$temp) # get ´
+  data_temp$temp <- gsub("\u00b4", " ", data_temp$temp) # get ´
   data_temp$temp <- gsub("'", " ", data_temp$temp)
 
   # Parse names using rgnparser


### PR DESCRIPTION
This change tries to solve the following issue on CRAN when on debian-clang server:

`"Warning: unable to re-encode 'bdc_clean_names.R' line 934"`

Non-ASCII characters were re-encoded using the `stringi::stri_escape_unicode()` function:

Ex:

```r
stringi::stri_escape_unicode("´")
##> \\u00b4
```

However, there is no guarantee that this change will solve the problem.