### PR TITLE
Ensure `version` arg in `taxadb::td_create`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bdc
 Title: Biodiversity Data Cleaning
-Version: 1.1.1
+Version: 1.1.2
 Authors@R: c(
     person("Bruno", "Ribeiro", , "ribeiro.brr@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-7755-6715")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# bdc 1.1.2
+
+- fix database version in `taxadb::td_create` inside the `bdc_query_names_taxadb`.
+
 # bdc 1.1.1
 
 - `bdc_country_from_coordinates` now filter out countries with no data (`NA`).

--- a/R/bdc_query_names_taxadb.R
+++ b/R/bdc_query_names_taxadb.R
@@ -46,7 +46,7 @@
 #' * **slb**: SeaLifeBase (unavailable)
 #' * **wd**: Wikidata (unavailable)
 #' * **ott**: OpenTree Taxonomy (v. 2021)
-#' * **iucn**: International Union for Conservation of Nature (v. 2022)
+#' * **iucn**: International Union for Conservation of Nature (v. 2019)
 #'
 #' The bdc_query_names_taxadb processes as this:
 #'
@@ -223,7 +223,8 @@ bdc_query_names_taxadb <-
         db_version <- 2022
       },
       iucn = {
-        db_version <- 2019 ### TODO: Change to 2022
+        ## FIXME 2022-06-23: taxadb cannot parse the 2022 version yet (taxadb issue 88).
+        db_version <- 2019
       },
       ott = {
         db_version <- 2021
@@ -254,9 +255,12 @@ bdc_query_names_taxadb <-
     db_name <- paste0(db_version, "_", "dwc", "_", db)
     
     if (!has_table(db_name, taxadb::td_connect(bdc_taxadb_dir()))) {
-      taxadb::td_create(provider = db,
-                        schema = "dwc",
-                        overwrite = FALSE)
+      taxadb::td_create(
+        provider = db,
+        schema = "dwc",
+        version = db_version,
+        overwrite = FALSE
+      )
     }
     
     # Raw taxa names

--- a/man/bdc_query_names_taxadb.Rd
+++ b/man/bdc_query_names_taxadb.Rd
@@ -75,7 +75,7 @@ momentary unavailable in taxadb.
 \item \strong{slb}: SeaLifeBase (unavailable)
 \item \strong{wd}: Wikidata (unavailable)
 \item \strong{ott}: OpenTree Taxonomy (v. 2021)
-\item \strong{iucn}: International Union for Conservation of Nature (v. 2022)
+\item \strong{iucn}: International Union for Conservation of Nature (v. 2019)
 }
 
 The bdc_query_names_taxadb processes as this:


### PR DESCRIPTION
When omitted, the default value is `taxadb::latest_version`; which is
the opposite of what we want since we have the fixed versions of the
databases.

Related to #228.