### PR TITLE
hotfix latest database releases from `{taxadb}`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bdc
 Title: Biodiversity Data Cleaning
-Version: 1.1.3
+Version: 1.1.4
 Authors@R: c(
     person("Bruno", "Ribeiro", , "ribeiro.brr@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-7755-6715")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# bdc 1.1.4
+
+- Adaptation of the databases to the latest version of `{taxadb}`
+  (0.2.0), temporarily discontinuing the `tpl`, `fb` and `iucn`
+  databases (see [here](https://github.com/ropensci/taxadb/commit/593c7856a603c802762829d60acb2a313ad7a6dd)).
+
+- `bdc_query_names_taxadb()` now informs the database provider and its version.
+
 # bdc 1.1.3
 
 - `bdc_standardize_datasets` now throws an error when dataset names defined in the metadata file are not unique.

--- a/R/bdc_query_names_taxadb.R
+++ b/R/bdc_query_names_taxadb.R
@@ -202,8 +202,9 @@ bdc_query_names_taxadb <-
                    "iucn")) {
       stop(db, " provided is not a valid name")
     }
-    
-    if (db %in% c("slb", "wd")) {
+    ## NOTE 2023-02-25: This modification is based on latest release of `{taxadb}` 0.2.0.
+    ## CHECK 2023-02-25: https://github.com/ropensci/taxadb/commit/593c7856a603c802762829d60acb2a313ad7a6dd
+    if (db %in% c("slb", "wd", "tpl", "fb", "iucn")) {
       stop(db, " database is momentarily unavailable in taxadb package")
     }
     
@@ -211,32 +212,34 @@ bdc_query_names_taxadb <-
     switch(
       EXPR = db,
       itis = {
-        db_version <- 2022
+        db_version <- "22.12"
       },
       ncbi = {
-        db_version <- 2022
+        db_version <- "22.12"
       },
       col = {
-        db_version <- 2022
+        db_version <- "22.12"
       },
       gbif = {
-        db_version <- 2022
+        db_version <- "22.12"
       },
       iucn = {
         ## FIXME 2022-06-23: taxadb cannot parse the 2022 version yet (taxadb issue 88).
-        db_version <- 2019
+        db_version <- "22.12"
       },
       ott = {
-        db_version <- 2021
+        db_version <- "22.12"
       },
       fb = {
-        db_version <- 2019
+        db_version <- "22.12"
       },
       tpl = {
-        db_version <- 2019
+        db_version <- "22.12"
       }
     )
-    
+
+    message("\nQuerying using ", db, " database version ", db_version, "\n")
+
     # Create a directory to save the result
     bdc_create_dir()
     
@@ -607,7 +610,7 @@ bdc_query_names_taxadb <-
     # joining  names queried to the original (complete) database
     found_name <-
       dplyr::left_join(raw_sci_name, found_name, by = "original_search")
-    
+
     end <- Sys.time()
     total_time <- round(as.numeric(end - start, units = "mins"), 1)
     

--- a/tests/testthat/test-bdc_query_names_taxadb.R
+++ b/tests/testthat/test-bdc_query_names_taxadb.R
@@ -74,3 +74,86 @@ expected$notes <- rep("notFound", 2)
 test_that("suggest_name FALSE", {
   testthat::expect_equal(test, expected)
 })
+
+
+## NOTE 2023-02-25: This modification is based on latest release of `{taxadb}` 0.2.0.
+## CHECK 2023-02-25: https://github.com/ropensci/taxadb/commit/593c7856a603c802762829d60acb2a313ad7a6dd
+
+## Testing database availability
+
+test_that("availability of itis", {
+
+  query_itis <- try(bdc_query_names_taxadb(sci_name = sci_names, db = "itis"))
+
+  expect_true(class(query_itis)[3] == "data.frame")
+
+})
+
+## FIXME 2023-02-25: Consciously ignoring that database for now.
+## test_that("availability of ncbi", {
+##   query_ncbi <- try(bdc_query_names_taxadb(sci_name = sci_names, db = "ncbi"))
+##   expect_true(class(query_ncbi)[3] == "data.frame")
+## })
+
+test_that("availability of col", {
+
+  query_col <- try(bdc_query_names_taxadb(sci_name = sci_names, db = "col"))
+
+  expect_true(class(query_col)[3] == "data.frame")
+
+})
+
+test_that("availability of tpl", {
+
+  query_tpl <- try(bdc_query_names_taxadb(sci_name = sci_names, db = "tpl"))
+
+  expect_true(class(query_tpl) == "try-error")
+
+})
+
+test_that("availability of gbif", {
+
+  query_gbif <- try(bdc_query_names_taxadb(sci_name = sci_names, db = "gbif"))
+
+  expect_true(class(query_gbif)[3] == "data.frame")
+
+})
+
+test_that("availability of fb", {
+
+  query_fb <- try(bdc_query_names_taxadb(sci_name = sci_names, db = "fb"))
+
+  expect_true(class(query_fb) == "try-error")
+
+})
+
+test_that("availability of slb", {
+
+  query_slb <- try(bdc_query_names_taxadb(sci_name = sci_names, db = "slb"))
+
+  expect_true(class(query_slb) == "try-error")
+
+})
+
+test_that("availability of wd", {
+
+  query_wd <- try(bdc_query_names_taxadb(sci_name = sci_names, db = "wd"))
+
+  expect_true(class(query_wd) == "try-error")
+
+})
+
+## ## FIXME 2023-02-25: Consciously ignoring that database for now.
+## test_that("availability of ott", {
+##   query_ott <- try(bdc_query_names_taxadb(sci_name = sci_names, db = "ott"))
+##   expect_true(class(query_ott)[3] == "data.frame")
+## })
+
+test_that("availability of iucn", {
+
+  query_iucn <- try(bdc_query_names_taxadb(sci_name = sci_names, db = "iucn"))
+
+  expect_true(class(query_iucn) == "try-error")
+
+})
+


### PR DESCRIPTION
New momentarily deprecated dbs: tpl, fb, iucn.

Unfortunately, db version is hardcoded for now.

Related to #245