### PR TITLE
move doParallel to Impors as it's used by default

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ URL: https://brunobrr.github.io/bdc/ (website)
 BugReports: https://github.com/brunobrr/bdc/issues
 Imports:
     CoordinateCleaner,
+    doParallel,
     dplyr,
     DT,
     foreach,
@@ -63,7 +64,6 @@ Suggests:
     covr,
     cowplot,
     DBI,
-    doParallel,
     duckdb (>= 0.3.2),
     knitr (>= 1.31),
     maps,


### PR DESCRIPTION
`doParallel` should move from `Suggests` to `Imports` since it's used by `bdc_suggest_names_taxadb()` by default.

closes #250