### PR TITLE
Fix issue 278

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -79,6 +79,8 @@ Suggests:
     testthat (>= 3.0.0)
 BuildVignettes: true
 VignetteBuilder: knitr, rmarkdown
+Remotes:
+    github::ropensci/taxadb@master
 Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-gb

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,11 +56,10 @@ Imports:
     stringdist,
     stringi,
     stringr,
-    taxadb (>= 0.1.3),
+    taxadb (>= 0.3.0),
     tibble,
     tidyselect
 Suggests:
-    contentid (>= 0.0.15),
     covr,
     cowplot,
     DBI,
@@ -84,4 +83,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-gb
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,15 @@
 - `reword-countries.txt` and `country_names.txt` were updated and fixed (by @sjevelazco; [274](https://github.com/brunobrr/bdc/pull/274)).
 - Migrated from `{qs}` to `{qs2}` package. Updated `bdc_standardize_datasets()` to use `qs2::qs_save()` and `qs2::qs_read()` instead of `qs::qsave()` and `qs::qread()`. The format option has been changed from `"qs"` to `"qs2"` and file extensions from `.qs` to `.qs2`.
 
+## taxadb 0.3.0 compatibility (#278)
+
+- `bdc_query_names_taxadb()` and `bdc_filter_name()` / `bdc_filter_id()` pin `db_version = "22.12"`, which remains available and byte-identical at the new data location (source.coop Parquet). No change needed for existing scripts.
+- `fb` (FishBase) and `slb` (SeaLifeBase) are republished in taxadb 0.3.0 in version 2026 (CC-BY-NC), but remain blocked in `bdc_query_names_taxadb()` because bdc pins `db_version = "22.12"`, which does not include them. The error message now directs users to `taxadb::available_providers("2026")`.
+- `iucn`, `tpl`, and `wd` remain blocked with an updated error message: iucn cannot be redistributed under Red List terms, TPL was retired upstream in 2013, and wd was never published. Use `rredlist` for Red List data.
+- Removed the `## FIXME` note referencing ropensci/taxadb#88, which is closed.
+- Removed dead `contentid` / `TAXADB_DRIVER` environment-variable code in `bdc_suggest_names_taxadb()`, superseded by the Parquet-on-source.coop reading layer.
+- Bumped `taxadb` dependency from `>= 0.1.3` to `>= 0.3.0`; removed `contentid` from Suggests.
+
 # bdc 1.1.5
 
 - Move `{doParallel}` from Suggests to Imports (Thanks, @black-snow; PR #251).

--- a/R/bdc_query_names_taxadb.R
+++ b/R/bdc_query_names_taxadb.R
@@ -34,18 +34,19 @@
 #' The lastest version of each database is used to perform queries, but
 #' note that only older versions are available for some taxonomic databases. The
 #' database version is shown in parenthesis. Note that some databases are
-#' momentary unavailable in taxadb.
+#' unavailable in taxadb.
 #'
 #' * **itis**: Integrated Taxonomic Information System (v. 2022)
 #' * **ncbi**: National Center for Biotechnology Information (v. 2022)
 #' * **col**: Catalogue of Life (v. 2022)
-#' * **tpl**: The Plant List (v. 2019)
 #' * **gbif**: Global Biodiversity Information Facility (v. 2022)
-#' * **fb**: FishBase (v. 2019)
-#' * **slb**: SeaLifeBase (unavailable)
-#' * **wd**: Wikidata (unavailable)
 #' * **ott**: OpenTree Taxonomy (v. 2021)
-#' * **iucn**: International Union for Conservation of Nature (v. 2019)
+#' * **fb**: FishBase (CC-BY-NC; available in taxadb 2026, not in pinned 22.12)
+#' * **slb**: SeaLifeBase (CC-BY-NC; available in taxadb 2026, not in pinned 22.12)
+#' * **tpl**: The Plant List (retired upstream in 2013; unavailable)
+#' * **wd**: Wikidata (never published; unavailable)
+#' * **iucn**: International Union for the Conservation of Nature (Red List
+#'   terms prohibit redistribution; unavailable; use \pkg{rredlist} instead)
 #'
 #' The bdc_query_names_taxadb processes as this:
 #'
@@ -201,10 +202,17 @@ bdc_query_names_taxadb <-
                    "iucn")) {
       stop(db, " provided is not a valid name")
     }
-    ## NOTE 2023-02-25: This modification is based on latest release of `{taxadb}` 0.2.0.
-    ## CHECK 2023-02-25: https://github.com/ropensci/taxadb/commit/593c7856a603c802762829d60acb2a313ad7a6dd
-    if (db %in% c("slb", "wd", "tpl", "fb", "iucn")) {
-      stop(db, " database is momentarily unavailable in taxadb package")
+    ## NOTE 2026-08-26: taxadb 0.3.0 republishes fb and slb in version 2026,
+    ## but bdc pins 22.12 for reproducibility and that version does not
+    ## include fb or slb. iucn, tpl, and wd are formally removed
+    ## (ropensci/taxadb#124): iucn cannot be redistributed under Red List
+    ## terms; TPL was retired upstream in 2013; wd was never published.
+    if (db %in% c("fb", "slb")) {
+      stop(db, " database is not available in taxadb version 22.12; ",
+           "published in 2026 (see taxadb::available_providers(\"2026\"))")
+    }
+    if (db %in% c("tpl", "wd", "iucn")) {
+      stop(db, " database is unavailable in taxadb package")
     }
     
     # Currently available databases and versions
@@ -223,7 +231,6 @@ bdc_query_names_taxadb <-
         db_version <- "22.12"
       },
       iucn = {
-        ## FIXME 2022-06-23: taxadb cannot parse the 2022 version yet (taxadb issue 88).
         db_version <- "22.12"
       },
       ott = {

--- a/R/bdc_suggest_names_taxadb.R
+++ b/R/bdc_suggest_names_taxadb.R
@@ -74,11 +74,6 @@ bdc_suggest_names_taxadb <-
            ncores = 2) {
     suggestion_distance <- db <- . <- .data <- scientificName <- NULL
 
-    # FIXME: set a env var for now
-    # REVIEW: https://github.com/ropensci/taxadb/issues/91
-    # Sys.setenv("CONTENTID_REGISTRIES" = "https://hash-archive.carlboettiger.info")
-    # Sys.setenv("TAXADB_DRIVER"="MonetDBLite")
-
     # Get first letter of all scientific names
     first_letter <-
       unique(sapply(sci_name, function(i) {
@@ -87,9 +82,7 @@ bdc_suggest_names_taxadb <-
       USE.NAMES = FALSE
       ))
 
-    name_to_case_check <- suppressMessages(taxadb::taxa_tbl(provider
-                                           # , version = getOption("taxadb_default_provider", db_version)
-                                           )) %>%
+    name_to_case_check <- suppressMessages(taxadb::taxa_tbl(provider)) %>%
       dplyr::filter(!is.na(scientificName)) %>%
       utils::head(1) %>%
       pull(scientificName) %>%

--- a/R/bdc_suggest_names_taxadb.R
+++ b/R/bdc_suggest_names_taxadb.R
@@ -65,9 +65,9 @@
 #' }
 bdc_suggest_names_taxadb <-
   function(sci_name,
-           max_distance = suggestion_distance,
-           provider = db,
-           db_version = db_version,
+           max_distance = 0.9,
+           provider = "gbif",
+           db_version = "22.12",
            rank_name = NULL,
            rank = NULL,
            parallel = TRUE,
@@ -82,7 +82,7 @@ bdc_suggest_names_taxadb <-
       USE.NAMES = FALSE
       ))
 
-    name_to_case_check <- suppressMessages(taxadb::taxa_tbl(provider)) %>%
+    name_to_case_check <- suppressMessages(taxadb::taxa_tbl(provider, version = db_version)) %>%
       dplyr::filter(!is.na(scientificName)) %>%
       utils::head(1) %>%
       pull(scientificName) %>%
@@ -101,7 +101,7 @@ bdc_suggest_names_taxadb <-
     # Should taxonomic database be filtered according to a taxonomic rank name?
     if (!is.null(rank_name) & !is.null(rank)) {
       species_first_letter <-
-        suppressMessages(taxadb::taxa_tbl(provider)) %>%
+        suppressMessages(taxadb::taxa_tbl(provider, version = db_version)) %>%
         dplyr::filter(., .data[[rank]] == rank_name | is.na(.data[[rank]])) %>%
         dplyr::pull(scientificName) %>%
         grep(paste0("^", first_letter, collapse = "|"), ., value = TRUE)
@@ -111,7 +111,7 @@ bdc_suggest_names_taxadb <-
       stop("Please, provide both 'rank_name' and 'rank' arguments")
     } else {
       species_first_letter <-
-        suppressMessages(taxadb::taxa_tbl(provider)) %>%
+        suppressMessages(taxadb::taxa_tbl(provider, version = db_version)) %>%
         dplyr::pull(scientificName) %>%
         grep(paste0("^", first_letter, collapse = "|"), ., value = TRUE)
     }

--- a/man/bdc_query_names_taxadb.Rd
+++ b/man/bdc_query_names_taxadb.Rd
@@ -63,18 +63,19 @@ The taxonomic harmonization is based upon one taxonomic authority database.
 The lastest version of each database is used to perform queries, but
 note that only older versions are available for some taxonomic databases. The
 database version is shown in parenthesis. Note that some databases are
-momentary unavailable in taxadb.
+unavailable in taxadb.
 \itemize{
 \item \strong{itis}: Integrated Taxonomic Information System (v. 2022)
 \item \strong{ncbi}: National Center for Biotechnology Information (v. 2022)
 \item \strong{col}: Catalogue of Life (v. 2022)
-\item \strong{tpl}: The Plant List (v. 2019)
 \item \strong{gbif}: Global Biodiversity Information Facility (v. 2022)
-\item \strong{fb}: FishBase (v. 2019)
-\item \strong{slb}: SeaLifeBase (unavailable)
-\item \strong{wd}: Wikidata (unavailable)
 \item \strong{ott}: OpenTree Taxonomy (v. 2021)
-\item \strong{iucn}: International Union for Conservation of Nature (v. 2019)
+\item \strong{fb}: FishBase (CC-BY-NC; available in taxadb 2026, not in pinned 22.12)
+\item \strong{slb}: SeaLifeBase (CC-BY-NC; available in taxadb 2026, not in pinned 22.12)
+\item \strong{tpl}: The Plant List (retired upstream in 2013; unavailable)
+\item \strong{wd}: Wikidata (never published; unavailable)
+\item \strong{iucn}: International Union for the Conservation of Nature (Red List
+terms prohibit redistribution; unavailable; use \pkg{rredlist} instead)
 }
 
 The bdc_query_names_taxadb processes as this:
@@ -191,8 +192,8 @@ if (interactive()) {
 }
 }
 \seealso{
-Other taxonomy: 
-\code{\link{bdc_clean_names}()},
-\code{\link{bdc_filter_out_names}()}
+Other taxonomy:
+\code{\link[=bdc_clean_names]{bdc_clean_names()}},
+\code{\link[=bdc_filter_out_names]{bdc_filter_out_names()}}
 }
 \concept{taxonomy}

--- a/tests/testthat/test-bdc_query_names_taxadb.R
+++ b/tests/testthat/test-bdc_query_names_taxadb.R
@@ -81,8 +81,9 @@ test_that("suggest_name FALSE", {
 })
 
 
-## NOTE 2023-02-25: This modification is based on latest release of `{taxadb}` 0.2.0.
-## CHECK 2023-02-25: https://github.com/ropensci/taxadb/commit/593c7856a603c802762829d60acb2a313ad7a6dd
+## NOTE 2026-08-26: fb and slb are republished in taxadb 0.3.0. ncbi and ott
+## remain commented because the pinned 22.12 snapshot has known defects (NCBI
+## accepted names had no taxonID). tpl, wd, and iucn are formally removed.
 
 ## Testing database availability
 
@@ -124,20 +125,22 @@ test_that("availability of gbif", {
 
 })
 
+# fb and slb are republished in taxadb 0.3.0 (version 2026 only, CC-BY-NC).
+# bdc pins 22.12, which does not include fb or slb, so they remain blocked.
 # test_that("availability of fb", {
-# 
+#
 #   query_fb <- try(bdc_query_names_taxadb(sci_name = sci_names, db = "fb"))
-# 
+#
 #   expect_true(class(query_fb) == "try-error")
-# 
+#
 # })
-
+#
 # test_that("availability of slb", {
-# 
+#
 #   query_slb <- try(bdc_query_names_taxadb(sci_name = sci_names, db = "slb"))
-# 
+#
 #   expect_true(class(query_slb) == "try-error")
-# 
+#
 # })
 
 # test_that("availability of wd", {
@@ -148,17 +151,18 @@ test_that("availability of gbif", {
 # 
 # })
 
-## ## FIXME 2023-02-25: Consciously ignoring that database for now.
+## FIXME 2026-08-26: ott 22.12 snapshot has known defects (synonyms had no
+## taxonomicStatus); left commented until bdc moves to a newer db_version.
 ## test_that("availability of ott", {
 ##   query_ott <- try(bdc_query_names_taxadb(sci_name = sci_names, db = "ott"))
 ##   expect_true(class(query_ott)[3] == "data.frame")
 ## })
 
 # test_that("availability of iucn", {
-# 
+#
 #   query_iucn <- try(bdc_query_names_taxadb(sci_name = sci_names, db = "iucn"))
-# 
+#
 #   expect_true(class(query_iucn) == "try-error")
-# 
+#
 # })
 

--- a/tests/testthat/test-bdc_suggest_names_taxadb.R
+++ b/tests/testthat/test-bdc_suggest_names_taxadb.R
@@ -44,7 +44,7 @@ res <-
       sci_name = sci_names,
       max_distance = 0.75,
       provider = "itis",
-      db_version = 2022,
+      db_version = "22.12",
       parallel = FALSE
     )
   )
@@ -121,7 +121,7 @@ res <-
       sci_name = sci_names,
       max_distance = 0.75,
       provider = "ott",
-      db_version = 2021,
+      db_version = "22.12",
       parallel = FALSE
     )
   )
@@ -148,7 +148,7 @@ res <-
       sci_name = sci_names,
       max_distance = 0.75,
       provider = "itis",
-      db_version = 2022,
+      db_version = "22.12",
       parallel = TRUE
     )
   )
@@ -175,7 +175,7 @@ res <- suppressWarnings(
     rank = "kingdom",
     max_distance = 0.75,
     provider = "itis",
-    db_version = 2022,
+      db_version = "22.12",
     parallel = FALSE
   )
 )
@@ -203,7 +203,7 @@ res <-
       rank = NULL,
       max_distance = 0.75,
       provider = "ott",
-      db_version = 2021,
+      db_version = "22.12",
       parallel = FALSE
     )
   ))
@@ -220,7 +220,7 @@ res <-
       rank = "kingdom",
       max_distance = 0.75,
       provider = "ott",
-      db_version = 2021,
+      db_version = "22.12",
       parallel = FALSE
     )
   ))


### PR DESCRIPTION
taxadb 0.3.0 compatibility (#278)

### Context

taxadb 0.3.0 is heading to CRAN. It changes the data backend from content-hashed GitHub releases to versioned Parquet on source.coop, read directly by duckdb. bdc pins db_version = "22.12" across all providers for reproducibility; that version is republished byte-identical at the new location, so existing scripts keep working unchanged.

### What changed

Dependency bump (DESCRIPTION)
- taxadb (>= 0.1.3) → taxadb (>= 0.3.0)
- Removed contentid from Suggests (no longer used by taxadb 0.3.0)
- Added Remotes: github::ropensci/taxadb@master until 0.3.0 reaches CRAN

Provider availability (R/bdc_query_names_taxadb.R)
- Split the single stop() into two blocks with distinct messages:
  - fb / slb: republished in taxadb 2026, but not in 22.12 — error directs users to taxadb::available_providers("2026")
  - tpl / wd / iucn: formally removed (TPL retired 2013, wd never published, iucn Red List terms prohibit redistribution — use rredlist)
- Removed ## FIXME referencing ropensci/taxadb#88 (closed)
- Updated roxygen provider list with CC-BY-NC notes for fb/slb and removal reasons for tpl/wd/iucn

Critical bug fix (R/bdc_suggest_names_taxadb.R)
- All three taxa_tbl(provider) calls were missing the version argument. In taxadb 0.2.x the default was 22.12 (the only published version). In 0.3.0, latest_version() was fixed — "22.12" no longer sorts above "2026" — so these calls silently read 2026 data, returning different scientificName strings (e.g. Oxalis rhombeo-ovata vs Oxalis rhombeoovata) and breaking 5 tests.
- Fix: pass version = db_version to all taxa_tbl() calls.
- Also fixed self-referential default arguments (db_version = db_version, provider = db, max_distance = suggestion_distance) — these were latent because db_version was never used in the function body. Once we started passing it to taxa_tbl(), R threw "promise already under evaluation". Replaced with concrete defaults ("22.12", "gbif", 0.9).
- Removed dead contentid / TAXADB_DRIVER env-var code (obsolete in 0.3.0).

Tests
- test-bdc_query_names_taxadb.R: updated FIXME comments; fb/slb tests remain commented (blocked in 22.12)
- test-bdc_suggest_names_taxadb.R: fixed version args from numeric 2022/2021 to "22.12"

Docs & NEWS
- man/bdc_query_names_taxadb.Rd: provider list regenerated via devtools::document()
- NEWS.md: new section under 1.1.6

### Verification

- R CMD check (local, --no-manual --no-build-vignettes): 0 errors, 1 warning (pre-existing vignette), 2 notes (pre-existing)
- testthat (20 tests across bdc_query_names_taxadb, bdc_suggest_names_taxadb, bdc_filter_name): FAIL 0 | WARN 0 | SKIP 0 | PASS 20
- CI on Windows confirmed the 5 suggest_names failures before the fix; all pass after

### Discrepancy with the issue

The issue reporter suggested dropping fb/slb from the stop() list. We verified that fb/slb are published only in version 2026, not in 22.12 which bdc pins. They remain blocked with an informative message pointing to available_providers("2026").

### When taxadb 0.3.0 lands on CRAN

Remove the Remotes: field from DESCRIPTION. No other changes needed.
