### PR TITLE
fix: replace deprecated tidyselect and ggplot2 calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 - `bdc_coordinates_country_inconsistent()` now resolves the `country_name` and the country column to a single canonical vocabulary before comparing names. Previously, records `in` the United States and Russia were wrongly flagged as inconsistent when the country was given by a common name ("United States", "Russia") or an ISO code ("US", "RU"), because the function compared Natural Earth's `name_long` (e.g. "Russian Federation", "United States of America") directly to `country_name`. Full names, common names, and ISO alpha-2/alpha-3 codes are now all accepted.
 - `reword-countries.txt` and `country_names.txt` were updated and fixed (by @sjevelazco; [274](https://github.com/brunobrr/bdc/pull/274)).
 - Migrated from `{qs}` to `{qs2}` package. Updated `bdc_standardize_datasets()` to use `qs2::qs_save()` and `qs2::qs_read()` instead of `qs::qsave()` and `qs::qread()`. The format option has been changed from `"qs"` to `"qs2"` and file extensions from `.qs` to `.qs2`.
++- Fixed deprecation warnings in `bdc_standardize_country()` (tidyselect `.data[[var]]` -> `all_of()`) and `bdc_quickmap()` (ggplot2 `borders()` -> `annotation_borders()`).
 
 ## taxadb 0.3.0 compatibility (#278)
 

--- a/R/bdc_quickmap.R
+++ b/R/bdc_quickmap.R
@@ -45,7 +45,7 @@ bdc_quickmap <- function(data, lat = "decimalLatitude", lon = "decimalLongitude"
   check_require_cran("ggplot2")
 
   world_borders <-
-    ggplot2::borders(
+    ggplot2::annotation_borders(
       database = "world",
       fill = "gray75",
       colour = "gray88",

--- a/R/bdc_standardize_country.R
+++ b/R/bdc_standardize_country.R
@@ -30,7 +30,7 @@ bdc_standardize_country <-
     cntr_db <-
       data %>%
       dplyr::distinct(.data[[country]], .keep_all = FALSE) %>%
-      dplyr::rename(cntr_original = .data[[country]])
+      dplyr::rename(cntr_original = dplyr::all_of(country))
     
     cntr_db$cntr_original2 <-
       gsub("&", "and", cntr_db$cntr_original) %>% 


### PR DESCRIPTION
Use dplyr::all_of() instead of .data[[var]] inside rename() to resolve the tidyselect 1.2.0 deprecation in bdc_standardize_country().

Use annotation_borders() instead of borders() to resolve the ggplot2 4.0.0 deprecation in bdc_quickmap().